### PR TITLE
Fix source-url

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -74,7 +74,7 @@
   "resources" : [
     "libraries/xml6"
   ],
-  "source-url" : "git://github.com/p6-pdf/LibXML-p6.git",
+  "source-url" : "https://github.com/p6-xml/LibXML-p6",
   "tags" : [
     "xml", "html", "xpath"
   ],


### PR DESCRIPTION
Doesn't seem to like `git://` as a protocol, also appears to be a copy pasto from a PDF repo